### PR TITLE
Добавлена опция склейки параграфов до минимального значения в символах

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -79,8 +79,9 @@ psql -U app -d lib < book-parser-backup-filename.sql
 
 ```
 -h --help помощь
--b, --batchSize int   размер пакета по умолчанию (default batch size) (default 3000)
--o, --output string   путь хранения файлов для обработки (default "./process/")
+-b, --batchSize int    размер пакета по умолчанию (default batch size) (default 3000)
+-m, --minParSize int   граница минимального размера параграфа в символах, если 0, то без склейки параграфов (default 800)
+-o, --output string    путь хранения файлов для обработки (default "./process/")
 ```
 
 ##### Сборка бинарника, нужно для разработки:

--- a/common/cmd/main.go
+++ b/common/cmd/main.go
@@ -19,6 +19,10 @@ var outputPath string
 // Default batch size
 var batchSize int
 
+// Минимальный размер получаемого после обработки параграфа, указывается в кол-ве символов.
+// Значение по умолчанию 800 символов, если указано значение 0, то склейки параграфов не будет
+var minParSize int
+
 func main() {
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt)
 
@@ -36,6 +40,7 @@ func main() {
 		3000,
 		"размер пакета по умолчанию (default batch size)",
 	)
+	flag.IntVarP(&minParSize, "minParSize", "m", 800, "граница минимального размера параграфа в символах, если 0, то без склейки параграфов")
 
 	flag.Parse()
 
@@ -81,7 +86,7 @@ func main() {
 		log.Fatal("unknown PARSER_STORE = ", storeType)
 	}
 
-	app := starter.NewApp(bookStore, paragraphStore, batchSize)
+	app := starter.NewApp(bookStore, paragraphStore, batchSize, minParSize)
 
 	// читаем все файлы в директории
 	files, err := os.ReadDir(outputPath)


### PR DESCRIPTION
Добавлена опция склейки мелких параграфов до минимальной границы.

**Значение по умолчанию установлено 800 символов.** 

Пул реквест пока повисит в статусе — открыт, позже сделаю слияние и выпуск.

При вызове парсера можно будет указать опцию `./book-parser.exe -m 250` и мелкие параграфы будут склеены до минимального размера, размер параграфа в символах станет не менее 250 символов.

Так же можно указать значение 0 при вызове `./book-parser.exe -m 0` и склейка параграфов производиться не будет, все будет как и ранее.

Вчера прогнал старый набор из 7733 файлов со склейкой параграфов до 800 символов, итоговое кол-во параграфов в БД уменьшилось до 4.6 миллионов вместо 22+ миллионов. Выигрыша в итоговом размере данных индекс и БД в Гб нет. 
Немного уменьшилась БД postgess. но увеличился индекс мантикоры.

Планирую сегодня протестировать на локальном на фронтенде., как будет происходить поиск.

Я вчера сделал тестовый вариант, и потом было ваше сообщение, есть связь:   

>  Если поискать сразу во всей книге с опцией «не далее чем столько символов», думаю деление на параграфы, возможно 2-3 параграфа, это будет наиболее оптимальным вариантом поиска. Это можно проверить. Про поиск в двух или трёх параграфах мы говорили ещё в начале. Но думаю на текущий момент и с одним всё в порядке.

https://github.com/terratensor/book-parser/issues/27#issuecomment-1641096537

