### PR TITLE
Добавлена обработка ошибок при открытии docx файла

### DIFF
--- a/common/app/starter/starter.go
+++ b/common/app/starter/starter.go
@@ -34,18 +34,21 @@ func NewApp(bookStore book.BookStore, paragraphStore paragraph.ParagraphStore, b
 
 func (app *App) Parse(ctx context.Context, n int, file os.DirEntry, path string) error {
 	fp := filepath.Clean(fmt.Sprintf("%v%v", path, file.Name()))
+
+	var filename = file.Name()
+	var extension = filepath.Ext(filename)
+	var name = filename[0 : len(filename)-len(extension)]
+
 	r, err := docc.NewReader(fp)
 	if err != nil {
-		panic(err)
+		str := fmt.Sprintf("%v, %v", filename, err)
+		log.Println(str)
+		return fmt.Errorf(str)
 	}
 	defer r.Close()
 
 	// position номер параграфа в индексе
 	position := 1
-
-	var filename = file.Name()
-	var extension = filepath.Ext(filename)
-	var name = filename[0 : len(filename)-len(extension)]
 
 	newBook, err := app.bs.Create(ctx, book.Book{
 		Name:     name,
@@ -64,7 +67,7 @@ func (app *App) Parse(ctx context.Context, n int, file os.DirEntry, path string)
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			str := fmt.Sprintf("%v , %v", filename, err)
+			str := fmt.Sprintf("%v, %v", filename, err)
 			log.Println(str)
 			return fmt.Errorf(str)
 		}

--- a/common/cmd/main.go
+++ b/common/cmd/main.go
@@ -130,7 +130,7 @@ func saveErrors(errors []string) {
 		defer f.Close()
 
 		for _, errorFile := range errors {
-			data := []byte(fmt.Sprintln(errorFile))
+			data := []byte(fmt.Sprint(errorFile))
 			f.Write(data)
 		}
 		log.Println(err)

--- a/common/cmd/main.go
+++ b/common/cmd/main.go
@@ -129,7 +129,7 @@ func saveErrors(errors []string) {
 		}
 		defer f.Close()
 
-		for errorFile := range errors {
+		for _, errorFile := range errors {
 			data := []byte(fmt.Sprintln(errorFile))
 			f.Write(data)
 		}


### PR DESCRIPTION
Теперь в случаях, когда в папке для обработки есть отличные от docx файлы, парсер не останавливает свою работу, а записывает сообщение об ошибке в error log  при попытке открыть файл отличный от docx


Это полезно в сценариях, когда остались артефакты, или обрабатываемый файл открыт в редакторе Word. Парсер не останавливает обработку.
```
-rwxrwxrwx 1 agusev agusev    162 Jul 20 11:32 '~$скин И.А. На пути к перелому — копия.docx'
-rwxrwxrwx 1 agusev agusev 685774 Jul 19 01:47 'Ласкин И.А. На пути к перелому — копия.docx'
```